### PR TITLE
Add iLand unit tests

### DIFF
--- a/tests/test_iland_data_processing.py
+++ b/tests/test_iland_data_processing.py
@@ -1,0 +1,63 @@
+import importlib.util
+from pathlib import Path
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+# Load modules from src-iLand/data_processing
+base = Path(__file__).resolve().parents[1] / 'src-iLand' / 'data_processing'
+models_spec = importlib.util.spec_from_file_location('models', base / 'models.py')
+models = importlib.util.module_from_spec(models_spec)
+models_spec.loader.exec_module(models)
+
+docproc_spec = importlib.util.spec_from_file_location('docproc', base / 'document_processor.py')
+docproc = importlib.util.module_from_spec(docproc_spec)
+docproc_spec.loader.exec_module(docproc)
+
+fileout_spec = importlib.util.spec_from_file_location('fileout', base / 'file_output.py')
+fileout = importlib.util.module_from_spec(fileout_spec)
+fileout_spec.loader.exec_module(fileout)
+
+
+def create_processor():
+    mappings = [
+        models.FieldMapping(csv_column='province', metadata_key='province', field_type='location'),
+        models.FieldMapping(csv_column='district', metadata_key='district', field_type='location'),
+        models.FieldMapping(csv_column='area_rai', metadata_key='area_rai', field_type='area_measurements'),
+        models.FieldMapping(csv_column='deed_type', metadata_key='deed_type', field_type='deed_info'),
+        models.FieldMapping(csv_column='land_use_type', metadata_key='land_use_type', field_type='land_details'),
+    ]
+    config = models.DatasetConfig(
+        name='test',
+        description='test',
+        field_mappings=mappings,
+        embedding_fields=['deed_type', 'province']
+    )
+    return docproc.DocumentProcessor(config)
+
+
+def test_convert_row_to_document(tmp_path):
+    processor = create_processor()
+    row = pd.Series({
+        'province': 'Bangkok',
+        'district': 'Bang Kapi',
+        'area_rai': 2,
+        'deed_type': 'Chanote',
+        'land_use_type': 'residential'
+    })
+    doc = processor.convert_row_to_document(row)
+
+    assert isinstance(doc, models.SimpleDocument)
+    assert doc.metadata['province'] == 'Bangkok'
+    assert doc.metadata['location_hierarchy'] == 'Bangkok > Bang Kapi'
+    assert doc.metadata['doc_type'] == 'land_deed_record'
+    assert doc.metadata['area_formatted'].startswith('2')
+    assert doc.text.startswith('#')
+
+    out = tmp_path / 'out'
+    out.mkdir()
+    fm = fileout.FileOutputManager(str(out), processor.dataset_config)
+    jsonl = fm.save_documents_as_jsonl([doc], 'docs.jsonl')
+    assert Path(jsonl).exists()
+    md_files = fm.save_documents_as_markdown_files([doc], prefix='doc', batch_size=1)
+    assert md_files

--- a/tests/test_iland_docs_embedding.py
+++ b/tests/test_iland_docs_embedding.py
@@ -1,0 +1,25 @@
+import importlib.util
+from pathlib import Path
+import pytest
+
+# Load metadata_extractor module
+base = Path(__file__).resolve().parents[1] / 'src-iLand' / 'docs_embedding'
+meta_spec = importlib.util.spec_from_file_location('meta', base / 'metadata_extractor.py')
+meta = importlib.util.module_from_spec(meta_spec)
+meta_spec.loader.exec_module(meta)
+
+
+def test_metadata_extraction_and_categories():
+    extractor = meta.iLandMetadataExtractor()
+    content = """Deed Serial No: 123\nProvince: Bangkok\nLand Rai: 5\nDeed Total Square Wa: 800\nDeed Type: โฉนด\nLand Main Category: agricultural\nDeed Holding Type: Company\nRegion: ภาคกลาง"""
+    data = extractor.extract_from_content(content)
+    assert data['deed_serial_no'] == '123'
+    assert data['province'] == 'Bangkok'
+    assert data['land_rai'] == 5.0
+    cats = extractor.classify_content_types(content)
+    assert 'land_deed' in cats
+    derived = extractor.derive_categories(data)
+    assert derived['area_category'] == 'medium'
+    assert derived['region_category'] == 'central'
+    title = extractor.extract_document_title(data, 1)
+    assert 'Bangkok' in title


### PR DESCRIPTION
## Summary
- add unit tests for data_processing DocumentProcessor
- add unit tests for docs_embedding metadata extractor

## Testing
- `pytest tests/test_iland_data_processing.py tests/test_iland_docs_embedding.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6840564ab4448332ae0ff4c64f2cbaa0