### PR TITLE
Improve clean_value normalization

### DIFF
--- a/src-iLand/data_processing/document_processor.py
+++ b/src-iLand/data_processing/document_processor.py
@@ -26,10 +26,27 @@ class DocumentProcessor:
         if isinstance(value, str):
             # Clean whitespace
             value = value.strip()
+            # Normalize Thai punctuation to ASCII equivalents
+            punct_map = {
+                "\u2018": "'",  # ‘
+                "\u2019": "'",  # ’
+                "\u201c": '"',  # “
+                "\u201d": '"',  # ”
+                "\u2013": '-',  # –
+                "\u2014": '-',  # —
+                "\uff0c": ',',  # ，
+                "\uff01": '!',  # ！
+                "\uff1f": '?',  # ？
+                "\uff1a": ':',  # ：
+                "\uff1b": ';',  # ；
+                "\uff0e": '.',  # ．
+            }
+            value = value.translate(str.maketrans(punct_map))
             # Remove multiple spaces
             value = re.sub(r'\s+', ' ', value)
-            # Return None for empty strings
-            if not value or value.lower() in ['nan', 'null', 'none', '-']:
+            # Normalize common placeholders
+            placeholders = ['nan', 'null', 'none', '-', 'n/a', 'na', 'ไม่ระบุ']
+            if not value or value.lower() in placeholders or value in placeholders:
                 return None
         return value
     


### PR DESCRIPTION
## Summary
- enhance `clean_value` for Thai punctuation normalization and placeholder removal
- update unit tests for new cleaning behavior

## Testing
- `pytest tests/test_iland_data_processing.py -k "convert_row_to_document or clean_value_placeholders_and_punctuation" -q`

------
https://chatgpt.com/codex/tasks/task_e_6844223589f08332a4e21b1907de161c