### PR TITLE
Add unit tests for iLand modules

### DIFF
--- a/src-iLand/test/end_to_end_modules_test.py
+++ b/src-iLand/test/end_to_end_modules_test.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+BASE = Path(__file__).resolve().parents[1]
+MODULES = ['data_processing', 'docs_embedding', 'load_embedding', 'retrieval']
+
+def test_readme_files_exist():
+    for module in MODULES:
+        readme = BASE / module / 'README.md'
+        assert readme.exists()

--- a/src-iLand/test/unit_test_data_processing.py
+++ b/src-iLand/test/unit_test_data_processing.py
@@ -1,0 +1,50 @@
+import importlib.util
+import sys
+from pathlib import Path
+import pandas as pd
+
+# Load modules from src-iLand/data_processing
+BASE_DIR = Path(__file__).resolve().parents[1] / 'data_processing'
+
+models_spec = importlib.util.spec_from_file_location('models', BASE_DIR / 'models.py')
+models = importlib.util.module_from_spec(models_spec)
+models_spec.loader.exec_module(models)
+sys.modules['models'] = models
+
+processor_spec = importlib.util.spec_from_file_location('document_processor', BASE_DIR / 'document_processor.py')
+document_processor = importlib.util.module_from_spec(processor_spec)
+processor_spec.loader.exec_module(document_processor)
+
+
+def _create_processor():
+    mappings = [
+        models.FieldMapping(csv_column='province', metadata_key='province', field_type='location'),
+        models.FieldMapping(csv_column='district', metadata_key='district', field_type='location'),
+    ]
+    config = models.DatasetConfig(
+        name='test',
+        description='test',
+        field_mappings=mappings,
+        embedding_fields=['province']
+    )
+    return document_processor.DocumentProcessor(config)
+
+
+def test_clean_value_and_area_formatting():
+    proc = _create_processor()
+    # Placeholder values removed
+    assert proc.clean_value('ไม่ระบุ') is None
+    assert proc.clean_value(' N/A ') is None
+    # Thai punctuation normalized
+    assert proc.clean_value('“ทดสอบ”') == '"ทดสอบ"'
+    # Format area
+    display = proc.format_area_for_display(1, 2, 3)
+    assert '1 ไร่' in display and '2 งาน' in display and '3 ตร.ว.' in display
+
+
+def test_parse_geom_point():
+    proc = _create_processor()
+    result = proc.parse_geom_point('POINT(100.5 13.7)')
+    assert result['latitude'] == 13.7
+    assert result['longitude'] == 100.5
+    assert 'google.com/maps' in result['google_maps_url']

--- a/src-iLand/test/unit_test_docs_embedding.py
+++ b/src-iLand/test/unit_test_docs_embedding.py
@@ -1,0 +1,29 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1] / 'docs_embedding'
+
+extractor_spec = importlib.util.spec_from_file_location('metadata_extractor', BASE_DIR / 'metadata_extractor.py')
+metadata_extractor = importlib.util.module_from_spec(extractor_spec)
+extractor_spec.loader.exec_module(metadata_extractor)
+
+
+def test_metadata_extraction_and_title():
+    extractor = metadata_extractor.iLandMetadataExtractor()
+    content = (
+        'Deed Type: Chanote\n'
+        'Province: Bangkok\n'
+        'District: Bang Kapi\n'
+        'Deed Serial No: 1234\n'
+        'Land Rai: 2\n'
+    )
+    meta = extractor.extract_from_content(content)
+    assert meta['deed_type'] == 'Chanote'
+    assert meta['province'] == 'Bangkok'
+    types = extractor.classify_content_types(content)
+    assert 'land_deed' in types
+    derived = extractor.derive_categories(meta)
+    assert derived['area_category'] == 'small'
+    title = extractor.extract_document_title(meta, 1)
+    assert 'Chanote' in title and 'Bangkok' in title

--- a/src-iLand/test/unit_test_load_embedding.py
+++ b/src-iLand/test/unit_test_load_embedding.py
@@ -1,0 +1,36 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1] / 'load_embedding'
+
+models_spec = importlib.util.spec_from_file_location('models', BASE_DIR / 'models.py')
+models = importlib.util.module_from_spec(models_spec)
+models_spec.loader.exec_module(models)
+sys.modules['models'] = models
+
+loader_spec = importlib.util.spec_from_file_location('embedding_loader', BASE_DIR / 'embedding_loader.py')
+embedding_loader = importlib.util.module_from_spec(loader_spec)
+loader_spec.loader.exec_module(embedding_loader)
+
+
+def _create_loader(tmp_path):
+    config = models.EmbeddingConfig(embedding_dir=tmp_path)
+    tmp_path.mkdir(exist_ok=True)
+    return embedding_loader.iLandEmbeddingLoader(config)
+
+
+def test_filtering_functions(tmp_path):
+    loader = _create_loader(tmp_path)
+    embeddings = [
+        {"metadata": {"province": "Bangkok", "deed_type_category": "chanote", "search_text": "5 ไร่"}},
+        {"metadata": {"province": "Chiang Mai", "deed_type_category": "nor_sor_3", "search_text": "1 ไร่"}},
+    ]
+    by_province = loader.filter_embeddings_by_province(embeddings, "Bangkok")
+    assert len(by_province) == 1
+    by_deed = loader.filter_embeddings_by_deed_type(embeddings, ["nor_sor_3"])
+    assert len(by_deed) == 1
+    by_area = loader.filter_embeddings_by_area_range(embeddings, min_area_rai=2)
+    assert len(by_area) == 1
+    area = loader._extract_area_from_text("10 ไร่")
+    assert area == 10.0

--- a/src-iLand/test/unit_test_retrieval.py
+++ b/src-iLand/test/unit_test_retrieval.py
@@ -1,0 +1,25 @@
+import importlib.util
+from pathlib import Path
+import sys
+import types
+import numpy as np
+
+BASE_DIR = Path(__file__).resolve().parents[1] / 'retrieval'
+
+spec = importlib.util.spec_from_file_location('index_classifier', BASE_DIR / 'index_classifier.py')
+index_classifier = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(index_classifier)
+
+
+class DummyEmbed:
+    def get_text_embedding(self, text):
+        # return small deterministic vector
+        return [0.1, 0.2, 0.3]
+
+
+def test_classifier_embedding_mode(monkeypatch):
+    monkeypatch.setattr(index_classifier, 'OpenAIEmbedding', lambda *a, **k: DummyEmbed())
+    classifier = index_classifier.create_default_iland_classifier(api_key='test', mode='embedding')
+    result = classifier.classify_query('ที่ดินกรุงเทพ')
+    assert 'selected_index' in result
+    assert result['confidence'] >= 0

--- a/tests/test_production_rag.py
+++ b/tests/test_production_rag.py
@@ -1,13 +1,16 @@
-"""
-Test script for Production RAG features in iLand batch embedding pipeline.
-"""
+"""Test script for Production RAG features in iLand batch embedding pipeline."""
+
+from pathlib import Path
+import sys
+
+# Add docs_embedding directory to path so `batch_embedding` can be imported
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src-iLand' / 'docs_embedding'))
 
 from batch_embedding import (
-    iLandBatchEmbeddingPipeline, 
+    iLandBatchEmbeddingPipeline,
     create_iland_production_query_engine,
     CONFIG
 )
-from pathlib import Path
 
 def test_path_configuration():
     """Test that paths are correctly configured."""


### PR DESCRIPTION
## Summary
- add new unit tests for data_processing, docs_embedding, load_embedding, retrieval
- basic end-to-end test that checks README files exist
- fix production rag test import path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c2eec9048332bfac457ccbc37af2