### PR TITLE
Fix csv analyzer imports for tests

### DIFF
--- a/src-iLand/data_processing/csv_analyzer.py
+++ b/src-iLand/data_processing/csv_analyzer.py
@@ -2,8 +2,13 @@ import pandas as pd
 import re
 import logging
 from typing import List, Dict, Any
-from ..common.thai_provinces import THAI_PROVINCES
+
 # Handle both relative and absolute imports
+try:
+    from ..common.thai_provinces import THAI_PROVINCES
+except ImportError:  # When package context is missing
+    from common.thai_provinces import THAI_PROVINCES
+
 try:
     from .models import FieldMapping, DatasetConfig
 except ImportError:


### PR DESCRIPTION
## Summary
- handle missing package context in `csv_analyzer`
- keep Streamlit improvements with chat history export

## Testing
- `python -m py_compile src-iLand/retrieval/streamlit_cli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68462ee05e0483329133c51a72f3099d